### PR TITLE
Adds a standard way of installing on Windows and POSIX-compliant plat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+CMakeFiles/
+CMakeCache.txt
+Makefile
+cmake_install.cmake
+install_manifest.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(clownresampler)
+add_library(libclownresampler INTERFACE)
+set_target_properties(libclownresampler PROPERTIES PUBLIC_HEADER "clownresampler.h")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(inc_dest $ENV{COMMONFILES})
+else()
+  set(inc_dest /usr/local/include)
+endif()
+
+install(TARGETS libclownresampler
+	PUBLIC_HEADER DESTINATION ${inc_dest})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # clownresampler
 
-This is a single-file library for resampling audio. It is written in C89 and
-dual-licenced under the terms of The Unlicence and the Zero-Clause BSD licence.
+This is a single-file header-only library for resampling audio. It is written in C89 
+and dual-licenced under the terms of The Unlicence and the Zero-Clause BSD licence.
 In particular, this library implements a windowed-sinc resampler, using a
 Lanczos window.
+
+To install this header into the standard include directory from the command line, 
+run the following commands:
+
+```
+cmake .
+make install
+```


### PR DESCRIPTION
I added a CMakeLists.txt which installs the header to the standard destination for user header files as part of making building the clownmdemu example frontend easier. I noticed that you keep copies of src files for clownmdemu under frontend/libraries, but multiple libraries are currently missing there. Rather than continually update the dependencies in that dir, I propose asking the user to install the necessary libraries. Should you ever need to update the deps, you won't be forced to choose between fixing other peoples' compiler errors or subverting '-Werror -Wall'.

If $COMMONDIR is not the right place to pull user headers from on Windows, I have no objections to changing it.